### PR TITLE
Use object reference modules

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 const minimist = require('minimist')
+const find = require('dlv')
+const set = require('dset')
 
 const splitter = process.argv.slice(2).indexOf('--')
 
@@ -21,27 +23,3 @@ if (beforeArgv && beforeArgv.json) {
 }
 
 process.stdout.write(JSON.stringify(afterArgv))
-
-function find(obj, ref) {
-	if (typeof ref === 'string') {
-		return find(obj, ref.split('.'))
-	} else if (!obj) {
-		return undefined
-	} else if (ref.length === 0) {
-		return obj
-	} else {
-		return find(obj[ref[0]], ref.slice(1))
-	}
-}
-
-function set(obj, ref, value) {
-	if (typeof ref === 'string') {
-		return set(obj, ref.split('.'), value)
-	} else if (ref.length === 1 && value) {
-		return obj[ref[0]] = value
-	} else if (ref.length === 0) {
-		return obj
-	} else {
-		return set(obj[ref[0]], ref.slice(1), value)
-	}
-}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "homepage": "https://github.com/saibotsivad/minimist-json#readme",
   "dependencies": {
+    "dlv": "^1.1.2",
+    "dset": "^2.0.1",
     "minimist": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use a couple tiny, well-tested modules for object referencing:
- https://github.com/lukeed/dset ([index.js](https://github.com/lukeed/dset/blob/master/src/index.js), [test.js](https://github.com/lukeed/dset/blob/master/test/index.js))
- https://github.com/developit/dlv ([index.js](https://github.com/developit/dlv/blob/master/index.js), [test.js](https://github.com/developit/dlv/blob/master/test.js))

Note, these modules use the `export default` keywords. I don't think this is an issue because you're using the `const` keyword. But maybe there's a version of node that supports `const` but not `export default`? Node 4? Maybe this is a breaking change. The tests passed for me. (node v10)