### PR TITLE
Update minimist dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/saibotsivad/minimist-json#readme",
   "dependencies": {
-    "minimist": "1.2.0"
+    "minimist": "1.2.3"
   },
   "devDependencies": {
     "tape": "4.5.1"


### PR DESCRIPTION
Minimist versions < 1.2.3 throws a security vulnerability warning when running `npm audit`. It was patched in `>=0.2.1 <1.0.0 || >=1.2.3`. 

(hi!)